### PR TITLE
Bug fix for incorrect path to bg.png in error layout

### DIFF
--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -10,7 +10,7 @@
       
 		html {
 			height: 100%;
-			background: #fff asset_url("custom_error_pages/bg.png") bottom repeat-x;
+			background: #fff url('<%= asset_path("exception_handler/bg.png") %>') bottom repeat-x;
 		}
 		
 		body {


### PR DESCRIPTION
I correct path to bg.png in error layout, because it is not executable code and had incorrect directory name.
