### PR TITLE
Add per-exception handling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,15 +248,31 @@ You get access to `%{message}` and `%{status}`, both inferring from `@exception`
 
 ---
 
-## Layout
+## Exception Handling Options
 
-**The `layout` has also been improved ↴**
+Exception options can be controlled using the `exceptions` hash in the config. Each status code can be assigned a set of options. If options are left unassigned,
+they will default to the `all` entry.
 
-![Layout][layout_img]
 
-We now assign layouts to the **status code** of the response:
-
-![Layout][layouts_img]
+    # config/application.rb
+    config.exception_handler = {
+      email: "your@email.com",
+      exceptions: {
+        :all=> {
+          layout: 'my_custom_layout'
+        },
+        404  => { 
+          deliver: proc {|e| e.request.original_fullpath =~ /jpg|png/ }
+        },
+      }
+    }
+    
+#### Options
+- `layout`:
+  The name of the layout used for this status code. Accepts `nil`, `String`, or `Proc` with the exception as the argumen
+- `deliver`:
+  If an email address is provided in the config, whether an email should be delivered for this status code. Accepts `true`, `false`, or `Proc` with the exception as the argument
+  
 
 By default, `5xx` errors are shown with our [`exception` layout][layout] - this can be overridden by changing the `config` to use a layout of your choice. If you want to inherit the `ApplicationController` layout, assign the codes to `nil`.
 

--- a/app/controllers/exception_handler/exceptions_controller.rb
+++ b/app/controllers/exception_handler/exceptions_controller.rb
@@ -49,7 +49,12 @@ module ExceptionHandler
     private
 
     def layout
-      ExceptionHandler.config.layouts[@exception.status]
+      status = @exception.status
+      opts = ExceptionHandler.config.exceptions[status] || ExceptionHandler.config.exceptions[:all]
+      case opts[:layout]
+      when Proc then opts[:layout].call(@exception)
+      else opts[:layout]
+      end
     end
 
     ##################################

--- a/app/mailers/exception_handler/exception_mailer.rb
+++ b/app/mailers/exception_handler/exception_mailer.rb
@@ -7,6 +7,18 @@ module ExceptionHandler
       # Defaults
       default from: 			    ExceptionHandler.config.email
       default template_path: 	"exception_handler/mailers" # => http://stackoverflow.com/a/18579046/1143732
+      
+      def self.should_notify?(exception)
+        defaults = ExceptionHandler.config.exceptions[:all]
+        options  = ExceptionHandler.config.exceptions[exception.status] || defaults
+
+        case options[:deliver]
+        when TrueClass, FalseClass then options[:deliver]
+        when Proc then options[:deliver].call(exception)
+        when nil then true # Deliver exceptions by default
+        else raise ArgumentError.new("Unexpected config value for exceptions[#{exception.status}]: #{options[:deliver].inspect}")
+        end
+      end
 
       def new_exception e
       	@exception = e

--- a/app/models/exception_handler/exception.rb
+++ b/app/models/exception_handler/exception.rb
@@ -97,7 +97,11 @@ module ExceptionHandler
         # => Email
         # => after_initialize invoked after .new method called
         # => Should have been after_create but user may not save
-        after_initialize Proc.new { |e| ExceptionHandler::ExceptionMailer.new_exception(e).deliver } if ExceptionHandler.config.try(:email).try(:is_a?, String)
+        after_initialize Proc.new { |e| 
+          if ExceptionHandler.config.try(:email).try(:is_a?, String) and ExceptionHandler::ExceptionMailer.should_notify?(e)
+            ExceptionHandler::ExceptionMailer.new_exception(e).deliver
+          end
+        }
 
         # => Attributes
         attr_accessor :request, :klass, :exception, :description

--- a/lib/exception_handler/version.rb
+++ b/lib/exception_handler/version.rb
@@ -13,8 +13,8 @@
 module ExceptionHandler
   module VERSION
     MAJOR = 0
-    MINOR = 7
-    TINY  = 7
+    MINOR = 8
+    TINY  = 0
     PRE   = 0 # "alpha"
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
This PR solves two problems. 

Rather than get thousands of 404 emails every day aimed at `wp-admin.php` and such, I decided to add some options to direct handling of these errors. 

In the case that the canned `exception` layout isn't desired, a layout must be supplied for each status code. Hardcoding the same thing for each status code didn't seem quite right, nor was I interested in getting bogged down with which HTTP codes are kosher to ignore. I initially handled this by configuring with `Hash[*(500..599).map{|x| [x, nil] }.flatten]` but that's not the right way to handle this either.

My solution is to move away from the `layouts` config option and rename it to `exceptions` (I'm happy to call this anything else too) in order to provide a place that each status code can be configured to be handled differently. For example, I want 500 errors delivered, with my 'something_broke' layout, but I don't want notification of 404 errors unless they are an image: 


    config.exception_handler = {
        email: 'email@example.com',
        exceptions: {
            :all => { layout: 'something_broke' },
             404  => { 
                deliver: proc {|e| e.request.original_fullpath =~ /jpg|png/ },
             },
        }
    }

Tests were performed, but I didn't see any test suite in the repo so I wasn't able to write any. I also gave a quick glance at the 0.8 branch and saw that the configuration options look unchanged, so hopefully this is simple enough to apply there as well.