### PR TITLE
Use verify_request_format! method to check valid request format

### DIFF
--- a/app/controllers/exception_handler/exceptions_controller.rb
+++ b/app/controllers/exception_handler/exceptions_controller.rb
@@ -22,7 +22,11 @@ module ExceptionHandler
 
     # => Response format (required for non-standard formats (.css / .gz etc))
     # => request.format required until responders updates with wildcard / failsafe (:all)
-    before_action { |e| e.request.format = :html unless self.class.respond_to.include? e.request.format }
+    before_action do |e|
+      verify_requested_format!
+    rescue
+      e.request.format = :html
+    end
 
     # => Routes
     # => Removes need for "main_app" prefix in routes


### PR DESCRIPTION
This commit fix a problem to be able to render error responses for 
format distinct to html (for example json) because e.request.format is
returning a Mime::Type object that doesn’t match with the values in 
self.class.respond_to that is a hash with keys :html, :json, etc

Using the responders’ verify_requested_format! we are getting exactly
the same goal delegating the tasks in the own responders gem.