### PR TITLE
Problem: use of `eval`

### DIFF
--- a/app/models/exception_handler/exception.rb
+++ b/app/models/exception_handler/exception.rb
@@ -26,7 +26,7 @@ module ExceptionHandler
         def initialize attributes={}
             super
             ATTRS.each do |type|
-              self[type] = eval type.to_s
+              self[type] = send(type)
             end
         end
 


### PR DESCRIPTION
It's potentially unsafe (arbitrary code execution) and is definitely
slow (requires resources for parsing, interpretation, etc.)

Solution: use `send` instead

It's faster (back-of-the-napkin benchmarking showed ~6x improvement)
and is safer (`send` has fewer potential exploitation vectors),
and it is actually providing better clarity into what's happening there.

Fixes #104 